### PR TITLE
Fetch rockets data from SpaceX API

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,18 +1,27 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import { useDispatch } from 'react-redux';
 import Header from './components/Header';
+import Rockets from './components/rockets/rockets';
+import { getRocketsData } from './redux/rockets/rockets';
 
-const App = () => (
-  <Router>
-    <Header />
-    <Routes>
-      <Route path="/" element={<h1>hi</h1>} />
-      <Route path="/rockets" element={<h1>rockets</h1>} />
-      <Route path="/dragons" element={<h1>dragons</h1>} />
-      <Route path="/missions" element={<h1>missions</h1>} />
-      <Route path="/profile" element={<h1>profile</h1>} />
-    </Routes>
-  </Router>
-);
+const App = () => {
+  const dispatch = useDispatch();
+  useEffect(() => {
+    dispatch(getRocketsData());
+  }, []);
+  return (
+    <Router>
+      <Header />
+      <Routes>
+        <Route path="/" element={<Rockets />} />
+        <Route path="/rockets" element={<Rockets />} />
+        <Route path="/dragons" element={<h1>dragons</h1>} />
+        <Route path="/missions" element={<h1>missions</h1>} />
+        <Route path="/profile" element={<h1>profile</h1>} />
+      </Routes>
+    </Router>
+  );
+};
 
 export default App;

--- a/src/components/rockets/rockets.jsx
+++ b/src/components/rockets/rockets.jsx
@@ -1,0 +1,11 @@
+import { useEffect } from 'react';
+
+const rockets = () => {
+  useEffect(() => {
+  }, []);
+  return (
+    <div>Rockets</div>
+  );
+};
+
+export default rockets;

--- a/src/redux/dragons/dragon.js
+++ b/src/redux/dragons/dragon.js
@@ -1,4 +1,5 @@
-const dragonReducer = (state, action) => {
+const initialState = {};
+const dragonReducer = (state = initialState, action) => {
   switch (action.type) {
     case 'ANY_TYPE':
       return state;

--- a/src/redux/missions/missions.js
+++ b/src/redux/missions/missions.js
@@ -1,4 +1,5 @@
-const missonsReducer = (state, action) => {
+const initialState = {};
+const missonsReducer = (state = initialState, action) => {
   switch (action.type) {
     case 'ANY_TYPE':
       return state;

--- a/src/redux/rockets/rockets.js
+++ b/src/redux/rockets/rockets.js
@@ -1,7 +1,31 @@
-const rocketsReducer = (state, action) => {
+const initialState = [];
+
+const GET_DATA = 'GET_DATA';
+
+export const getRocketsData = () => async (dispatch) => {
+  const response = await fetch('https://api.spacexdata.com/v3/rockets', {
+    method: 'GET',
+  });
+
+  const responseJSON = await response.json();
+  const data = responseJSON.map((rocket) => (
+    {
+      id: rocket.rocket_id,
+      name: rocket.rocket_name,
+      type: rocket.rocket_type,
+      flickr_images: rocket.flickr_images,
+    }
+  ));
+  dispatch({
+    type: GET_DATA,
+    data,
+  });
+};
+
+const rocketsReducer = (state = initialState, action) => {
   switch (action.type) {
-    case 'ANY_TYPE':
-      return state;
+    case GET_DATA:
+      return [...state, action.data];
     default:
       return state;
   }


### PR DESCRIPTION
Fetch data from the Rockets endpoint  (https://api.spacexdata.com/v3/rockets) when the application starts (as Rockets is the default view).

Once the data are fetched, dispatch an action to store the selected data in the Redux store:

- id
- name
- type
- flickr_images

NOTE: Make sure you only **dispatch those actions once and do not add data to store on every re-render** (i.e. when changing views / using navigation).