### PR TITLE
Space Travelers' Hub: Add tests for the dragons component

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test",
+    "test": "react-scripts test --verbose",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {

--- a/src/components/dragons/Dragons.test.jsx
+++ b/src/components/dragons/Dragons.test.jsx
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom';
-import { render } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import { Provider, useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
 import Dragons from './Dragons';
@@ -67,5 +67,18 @@ describe('Tests for the Dragons component', () => {
     );
 
     expect(getByText(/Test_Name1/i)).toBeInTheDocument();
+  });
+
+  test('The component should display a "Reserved" badge when the user clicks the Reserve Dragon button', () => {
+    const { getByText } = render(
+      <Provider store={store}>
+        <TestContainer action="FETCH_SUCCESS" />
+      </Provider>,
+    );
+
+    fireEvent.click(getByText(/Reserve Dragon/i));
+
+    expect(getByText(/Reserved/i)).toBeInTheDocument();
+    expect(getByText(/Cancel Reservation/i)).toBeInTheDocument();
   });
 });

--- a/src/components/dragons/Dragons.test.jsx
+++ b/src/components/dragons/Dragons.test.jsx
@@ -1,0 +1,31 @@
+import '@testing-library/jest-dom';
+import { render } from '@testing-library/react';
+import { Provider, useDispatch } from 'react-redux';
+import PropTypes from 'prop-types';
+import Dragons from './Dragons';
+import store from '../../redux/configStore';
+import { fetchDragonsBegin } from '../../redux/dragons/dragon';
+
+const TestContainer = ({ action }) => {
+  const dispatch = useDispatch();
+  dispatch(action());
+  return (
+    <Dragons />
+  );
+};
+
+TestContainer.propTypes = {
+  action: PropTypes.func.isRequired,
+};
+
+describe('Tests for the Dragons component', () => {
+  test('The component should display "LOADING..." when the fetching Dragons action starts', () => {
+    const { getByText } = render(
+      <Provider store={store}>
+        <TestContainer action={fetchDragonsBegin} />
+      </Provider>,
+    );
+
+    expect(getByText(/LOADING.../i)).toBeInTheDocument();
+  });
+});

--- a/src/components/dragons/Dragons.test.jsx
+++ b/src/components/dragons/Dragons.test.jsx
@@ -81,4 +81,22 @@ describe('Tests for the Dragons component', () => {
     expect(getByText(/Reserved/i)).toBeInTheDocument();
     expect(getByText(/Cancel Reservation/i)).toBeInTheDocument();
   });
+
+  test('When the user click the Cancel Reservation for a reserved item the "Reserved" badge should disappear and the button should say "Reserve Dragon"', () => {
+    const { getByText, queryByText } = render(
+      <Provider store={store}>
+        <TestContainer action="FETCH_SUCCESS" />
+      </Provider>,
+    );
+
+    fireEvent.click(getByText(/Reserve Dragon/i));
+
+    expect(getByText(/Reserved/i)).toBeInTheDocument();
+    expect(getByText(/Cancel Reservation/i)).toBeInTheDocument();
+
+    fireEvent.click(getByText(/Cancel Reservation/i));
+
+    expect(queryByText(/Reserved/i)).not.toBeInTheDocument();
+    expect(getByText(/Reserve Dragon/i)).toBeInTheDocument();
+  });
 });

--- a/src/components/dragons/Dragons.test.jsx
+++ b/src/components/dragons/Dragons.test.jsx
@@ -4,28 +4,68 @@ import { Provider, useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
 import Dragons from './Dragons';
 import store from '../../redux/configStore';
-import { fetchDragonsBegin } from '../../redux/dragons/dragon';
+import { fetchDragonsBegin, fetchDragonsFailed, fetchDragonsSucess } from '../../redux/dragons/dragon';
 
 const TestContainer = ({ action }) => {
   const dispatch = useDispatch();
-  dispatch(action());
+  switch (action) {
+    case 'FETCH_BEGIN':
+      dispatch(fetchDragonsBegin());
+      break;
+    case 'FETCH_FAILURE':
+      dispatch(fetchDragonsFailed(new Error('Test_Error')));
+      break;
+    case 'FETCH_SUCCESS':
+      dispatch(fetchDragonsSucess([{
+        id: 'Test_Item1',
+        name: 'Test_Name1',
+        type: 'Test_Type1',
+        description: 'Test_Description1',
+        flickr_images: 'Test_Image1',
+        reserved: false,
+      }]));
+      break;
+    default:
+      break;
+  }
+
   return (
     <Dragons />
   );
 };
 
 TestContainer.propTypes = {
-  action: PropTypes.func.isRequired,
+  action: PropTypes.string.isRequired,
 };
 
 describe('Tests for the Dragons component', () => {
   test('The component should display "LOADING..." when the fetching Dragons action starts', () => {
     const { getByText } = render(
       <Provider store={store}>
-        <TestContainer action={fetchDragonsBegin} />
+        <TestContainer action="FETCH_BEGIN" />
       </Provider>,
     );
 
     expect(getByText(/LOADING.../i)).toBeInTheDocument();
+  });
+
+  test('The component should display "Something went wrong: [ERROR]" when the fetching Dragons action fails', () => {
+    const { getByText } = render(
+      <Provider store={store}>
+        <TestContainer action="FETCH_FAILURE" />
+      </Provider>,
+    );
+
+    expect(getByText(/Something went wrong:/i)).toBeInTheDocument();
+  });
+
+  test('The component should display a list of dragons when the fetching Dragons action succeeds', () => {
+    const { getByText } = render(
+      <Provider store={store}>
+        <TestContainer action="FETCH_SUCCESS" />
+      </Provider>,
+    );
+
+    expect(getByText(/Test_Name1/i)).toBeInTheDocument();
   });
 });

--- a/src/redux/dragons/dragon.js
+++ b/src/redux/dragons/dragon.js
@@ -49,20 +49,20 @@ const dragonReducer = (state = {}, action) => {
   }
 };
 
-const fetchDragonsBegin = () => (
+export const fetchDragonsBegin = () => (
   {
     type: FETCH_DRAGONS_BEGAN,
   }
 );
 
-const fetchDragonsFailed = (error) => (
+export const fetchDragonsFailed = (error) => (
   {
     type: FETCH_DRAGONS_FAILED,
     error,
   }
 );
 
-const fetchDragonsSucess = (data) => (
+export const fetchDragonsSucess = (data) => (
   {
     type: FETCH_DRAGONS_SUCCEEDED,
     payload: data,


### PR DESCRIPTION
### Tests created:
In this branch, unit tests were added to the dragons component.
### Tests built for:
- Fetching  dragons begins.
- Fetching  dragons fail.
- Fetching  dragons succeeds
- User clicks the Reserve button.
- User clicks the Cancel button.